### PR TITLE
fixes issue "1 empty db raises exception"

### DIFF
--- a/bdr_deposits_uploader_app/lib/config_new_helper.py
+++ b/bdr_deposits_uploader_app/lib/config_new_helper.py
@@ -12,11 +12,22 @@ def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
     """
     Returns a list of app names.
     Called by views.hlpr_check_name_and_slug().
+    Example: say `apps` is:
+        [
+            ('App1', 'app1-slug'),
+            ('App2', 'app2-slug'),
+            ('App3', 'app3-slug'),
+        ]
+        ...then `names` would be:
+        ('App1', 'App2', 'App3'),  # All the 'name' values
+
+        ...and `slugs` would be:
+        ('app1-slug', 'app2-slug', 'app3-slug'),  # All the 'slug' values
     """
     apps = AppConfig.objects.values_list('name', 'slug')
     names: tuple[str, ...]  # elipsis indicates the tuple can contain any number of elements
     slugs: tuple[str, ...]
-    names, slugs = zip(*apps)
+    names, slugs = zip(*apps)  # zip is an iterator that aggregates elements from each of the iterables
     return [names, slugs]
 
 

--- a/bdr_deposits_uploader_app/lib/config_new_helper.py
+++ b/bdr_deposits_uploader_app/lib/config_new_helper.py
@@ -28,33 +28,73 @@ def get_configs() -> list:
     log.debug('starting get_configs()')
     existing_app_data: list = []
     apps = AppConfig.objects.all()
-    app_label = apps[0]._meta.app_label
-    log.debug(f'app_label, ``{app_label}``')
-    # model_name = apps[0]._meta.model_name
-    # log.debug(f'model_name, ``{model_name}``')
-    base_admin_url = reverse('admin:bdr_deposits_uploader_app_submission_changelist')
-    log.debug(f'base_admin_url, ``{base_admin_url}``')
-    for app in apps:
-        app_data: dict = {}
-        mod_date_without_microseconds: str = app.updated_at.strftime('%Y-%m-%d %H:%M:%S')
-        app_data['mod_date'] = mod_date_without_microseconds
-        app_data['name'] = app.name
-        submission_count_for_app = app.submission_set.count()
-        app_data['items_count'] = submission_count_for_app
-        app_data['config_link'] = f'{reverse("config_slug_url", args=[app.slug])}'
-        app_data['upload_link'] = f'{reverse("upload_slug_url", args=[app.slug])}'
-        # app_data['admin_link'] = reverse(
-        #     f'admin:{app_label}_{model_name}_change', args=[app.id]
-        # )  # works, but not what I want
+    if apps:
+        app_label = apps[0]._meta.app_label
+        log.debug(f'app_label, ``{app_label}``')
+        # model_name = apps[0]._meta.model_name
+        # log.debug(f'model_name, ``{model_name}``')
+        base_admin_url = reverse('admin:bdr_deposits_uploader_app_submission_changelist')
+        log.debug(f'base_admin_url, ``{base_admin_url}``')
+        for app in apps:
+            app_data: dict = {}
+            mod_date_without_microseconds: str = app.updated_at.strftime('%Y-%m-%d %H:%M:%S')
+            app_data['mod_date'] = mod_date_without_microseconds
+            app_data['name'] = app.name
+            submission_count_for_app = app.submission_set.count()
+            app_data['items_count'] = submission_count_for_app
+            app_data['config_link'] = f'{reverse("config_slug_url", args=[app.slug])}'
+            app_data['upload_link'] = f'{reverse("upload_slug_url", args=[app.slug])}'
+            # app_data['admin_link'] = reverse(
+            #     f'admin:{app_label}_{model_name}_change', args=[app.id]
+            # )  # works, but not what I want
 
-        query_params = {'app__id__exact': str(app.id)}
-        full_admin_url = f'{base_admin_url}?{urlencode(query_params)}'
-        app_data['admin_link'] = full_admin_url
+            query_params = {'app__id__exact': str(app.id)}
+            full_admin_url = f'{base_admin_url}?{urlencode(query_params)}'
+            app_data['admin_link'] = full_admin_url
 
-        existing_app_data.append(app_data)
+            existing_app_data.append(app_data)
+    else:
+        log.debug('no apps found')
 
     log.debug(f'existing_app_data, ``{existing_app_data}``')
     return existing_app_data
+
+
+# def get_configs() -> list:
+#     """
+#     Returns a list of app names and slugs. Will replace get_recent_configs() soon.
+#     Called by views.config_new().
+#     """
+#     log.debug('starting get_configs()')
+#     existing_app_data: list = []
+#     apps = AppConfig.objects.all()
+#     app_label = apps[0]._meta.app_label
+#     log.debug(f'app_label, ``{app_label}``')
+#     # model_name = apps[0]._meta.model_name
+#     # log.debug(f'model_name, ``{model_name}``')
+#     base_admin_url = reverse('admin:bdr_deposits_uploader_app_submission_changelist')
+#     log.debug(f'base_admin_url, ``{base_admin_url}``')
+#     for app in apps:
+#         app_data: dict = {}
+#         mod_date_without_microseconds: str = app.updated_at.strftime('%Y-%m-%d %H:%M:%S')
+#         app_data['mod_date'] = mod_date_without_microseconds
+#         app_data['name'] = app.name
+#         submission_count_for_app = app.submission_set.count()
+#         app_data['items_count'] = submission_count_for_app
+#         app_data['config_link'] = f'{reverse("config_slug_url", args=[app.slug])}'
+#         app_data['upload_link'] = f'{reverse("upload_slug_url", args=[app.slug])}'
+#         # app_data['admin_link'] = reverse(
+#         #     f'admin:{app_label}_{model_name}_change', args=[app.id]
+#         # )  # works, but not what I want
+
+#         query_params = {'app__id__exact': str(app.id)}
+#         full_admin_url = f'{base_admin_url}?{urlencode(query_params)}'
+#         app_data['admin_link'] = full_admin_url
+
+#         existing_app_data.append(app_data)
+
+#     log.debug(f'existing_app_data, ``{existing_app_data}``')
+#     return existing_app_data
 
 
 # def get_recent_configs() -> list:

--- a/bdr_deposits_uploader_app/lib/config_new_helper.py
+++ b/bdr_deposits_uploader_app/lib/config_new_helper.py
@@ -1,11 +1,36 @@
 import logging
 from urllib.parse import urlencode
 
+from django.db.models.query import QuerySet  # for type-hint
 from django.urls import reverse
 
 from bdr_deposits_uploader_app.models import AppConfig
 
 log = logging.getLogger(__name__)
+
+
+# def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
+#     """
+#     Returns a list of app names.
+#     Called by views.hlpr_check_name_and_slug().
+#     Example: say `apps` is:
+#         [
+#             ('App1', 'app1-slug'),
+#             ('App2', 'app2-slug'),
+#             ('App3', 'app3-slug'),
+#         ]
+#         ...then `names` would be:
+#         ('App1', 'App2', 'App3'),  # All the 'name' values
+
+#         ...and `slugs` would be:
+#         ('app1-slug', 'app2-slug', 'app3-slug'),  # All the 'slug' values
+#     """
+#     apps: QuerySet = AppConfig.objects.values_list('name', 'slug')
+#     log.debug(f'type(apps), ``{type(apps)}``')
+#     names: tuple[str, ...]  # elipsis indicates the tuple can contain any number of elements
+#     slugs: tuple[str, ...]
+#     names, slugs = zip(*apps)  # zip is an iterator that aggregates elements from each of the iterables
+#     return [names, slugs]
 
 
 def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
@@ -24,10 +49,16 @@ def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
         ...and `slugs` would be:
         ('app1-slug', 'app2-slug', 'app3-slug'),  # All the 'slug' values
     """
-    apps = AppConfig.objects.values_list('name', 'slug')
+    apps: QuerySet = AppConfig.objects.values_list('name', 'slug')
     names: tuple[str, ...]  # elipsis indicates the tuple can contain any number of elements
     slugs: tuple[str, ...]
-    names, slugs = zip(*apps)  # zip is an iterator that aggregates elements from each of the iterables
+    if not apps:
+        names = ()
+        slugs = ()
+    else:
+        names, slugs = zip(*apps)  # zip is an iterator that aggregates elements from each of the iterables
+    log.debug(f'names, ``{names}``')
+    log.debug(f'slugs, ``{slugs}``')
     return [names, slugs]
 
 

--- a/bdr_deposits_uploader_app/lib/config_new_helper.py
+++ b/bdr_deposits_uploader_app/lib/config_new_helper.py
@@ -9,30 +9,6 @@ from bdr_deposits_uploader_app.models import AppConfig
 log = logging.getLogger(__name__)
 
 
-# def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
-#     """
-#     Returns a list of app names.
-#     Called by views.hlpr_check_name_and_slug().
-#     Example: say `apps` is:
-#         [
-#             ('App1', 'app1-slug'),
-#             ('App2', 'app2-slug'),
-#             ('App3', 'app3-slug'),
-#         ]
-#         ...then `names` would be:
-#         ('App1', 'App2', 'App3'),  # All the 'name' values
-
-#         ...and `slugs` would be:
-#         ('app1-slug', 'app2-slug', 'app3-slug'),  # All the 'slug' values
-#     """
-#     apps: QuerySet = AppConfig.objects.values_list('name', 'slug')
-#     log.debug(f'type(apps), ``{type(apps)}``')
-#     names: tuple[str, ...]  # elipsis indicates the tuple can contain any number of elements
-#     slugs: tuple[str, ...]
-#     names, slugs = zip(*apps)  # zip is an iterator that aggregates elements from each of the iterables
-#     return [names, slugs]
-
-
 def get_existing_names_and_slugs() -> list[tuple[str, ...]]:
     """
     Returns a list of app names.


### PR DESCRIPTION
- first, J & N, no need to drop everything to review this -- I'm going to tag y'all on all my pull-requests. I'll likely go ahead and accept this PR soon to work on another issue. As N mentioned, these PRs can still be a focus for code-review / demo-check-in.

- the issue description said that clicking staff-login created an exception. I'm getting back to this app, and don't even remember that. I assume I fixed that and then got to the issue I just fixed -- that a step in creating a new 'app' caused an exception when the database was empty (when it was the first app being created).

- the reason for the exception was my logic for validating that a new app-name and app-slug were unique. FYI, that validation occurs using something called "[htmx](https://htmx.org)" -- basically a javascript library that makes making [ajax](https://en.wikipedia.org/wiki/Ajax_(programming)) calls easy.